### PR TITLE
ShellSensor attribute does not accept number

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ Set the `class` attribute to `ShellSwitch`. For example:
       "onCommand": "echo on > /home/pi/switchState",
       "offCommand": "echo off > /home/pi/switchState",
       "getStateCommand": "echo /home/pi/switchState",
-      "interval": 10000
+      "interval": 10000,
+      "forceExecution": false
     }
 
 If the `getStateCommand` option is set and the `interval` option is set to a value greater than 0, 

--- a/README.md
+++ b/README.md
@@ -36,11 +36,11 @@ Set the `class` attribute to `ShellSwitch`. For example:
     }
 
 If the `getStateCommand` option is set and the `interval` option is set to a value greater than 0, 
-the `getStateCommmand` is executed in this ms interval to update the state of the switch. 
+the `getStateCommand` is executed in this ms interval to update the state of the switch. 
 
 ### ShellSensor Device
 
-You can define a sensor whose attribute gets updated with the output of shell command:
+You can define a sensor device with an attribute which gets updated with the output of shell command:
 
     { 
       "id": "temperature",

--- a/device-config-schema.coffee
+++ b/device-config-schema.coffee
@@ -24,7 +24,7 @@ module.exports = {
           the time in ms, the command gets executed to get the actual state. 
           If 0 then the state will not updated automatically.
         "
-        type: "number"
+        type: "integer"
         default: 0
   }
   ShellSensor: {
@@ -61,7 +61,7 @@ module.exports = {
         default: "echo value"
       interval:
         description: "the time in ms, the command gets executed to get a new sensor value"
-        type: "number"
+        type: "integer"
         default: 5000
   }
   ShellPresenceSensor: {
@@ -81,7 +81,7 @@ module.exports = {
           the time in ms, the command gets executed to get the actual state.
           If 0 then the state will not updated automatically.
         "
-        type: "number"
+        type: "integer"
         default: 0
       autoReset:
         description: "

--- a/device-config-schema.coffee
+++ b/device-config-schema.coffee
@@ -35,7 +35,6 @@ module.exports = {
       attributeName:
         description: "the name of the attribute the sensor is monitoring"
         type: "string"
-        default: ""
       attributeType:
         description: "the type of the attribute the sensor is monitoring"
         type: "string"

--- a/device-config-schema.coffee
+++ b/device-config-schema.coffee
@@ -26,6 +26,12 @@ module.exports = {
         "
         type: "integer"
         default: 0
+      forceExecution:
+        description: "
+          always execute command even if switch already is set to the requested state
+        "
+        type: "boolean"
+        default: false
   }
   ShellSensor: {
     title: "ShellSensor config options"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "shell-execute-config-schema.coffee",
     "LICENSE"
   ],
-  "version": "0.9.0",
+  "version": "0.9.1",
   "homepage": "http://github.com/pimatic/pimatic",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "shell-execute-config-schema.coffee",
     "LICENSE"
   ],
-  "version": "0.9.5",
+  "version": "0.9.6",
   "homepage": "http://github.com/pimatic/pimatic",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "shell-execute-config-schema.coffee",
     "LICENSE"
   ],
-  "version": "0.9.1",
+  "version": "0.9.2",
   "homepage": "http://github.com/pimatic/pimatic",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "shell-execute-config-schema.coffee",
     "LICENSE"
   ],
-  "version": "0.9.2",
+  "version": "0.9.3",
   "homepage": "http://github.com/pimatic/pimatic",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "shell-execute-config-schema.coffee",
     "LICENSE"
   ],
-  "version": "0.9.6",
+  "version": "0.9.7",
   "homepage": "http://github.com/pimatic/pimatic",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "configSchema": "shell-execute-config-schema.coffee",
   "dependencies": {
-    "pimatic-plugin-commons": "^0.8.8"
+    "pimatic-plugin-commons": "^0.9.2"
   },
   "peerDependencies": {
     "pimatic": "0.9.*"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "shell-execute-config-schema.coffee",
     "LICENSE"
   ],
-  "version": "0.8.22",
+  "version": "0.9.0",
   "homepage": "http://github.com/pimatic/pimatic",
   "repository": {
     "type": "git",
@@ -23,7 +23,7 @@
     "pimatic-plugin-commons": "^0.8.7"
   },
   "peerDependencies": {
-    "pimatic": "0.8.*"
+    "pimatic": "0.9.*"
   },
   "engines": {
     "node": ">0.8.x",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "shell-execute-config-schema.coffee",
     "LICENSE"
   ],
-  "version": "0.9.4",
+  "version": "0.9.5",
   "homepage": "http://github.com/pimatic/pimatic",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "configSchema": "shell-execute-config-schema.coffee",
   "dependencies": {
-    "pimatic-plugin-commons": "^0.8.7"
+    "pimatic-plugin-commons": "^0.8.8"
   },
   "peerDependencies": {
     "pimatic": "0.9.*"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "shell-execute-config-schema.coffee",
     "LICENSE"
   ],
-  "version": "0.9.3",
+  "version": "0.9.4",
   "homepage": "http://github.com/pimatic/pimatic",
   "repository": {
     "type": "git",

--- a/shell-execute.coffee
+++ b/shell-execute.coffee
@@ -61,6 +61,7 @@ module.exports = (env) ->
       @name = @config.name
       @id = @config.id
       @base = commons.base @, @config.class
+      @forceExecution = @config.forceExecution
 
       @_state = lastState?.state?.value or off
 
@@ -101,7 +102,7 @@ module.exports = (env) ->
         )
         
     changeStateTo: (state) ->
-      if @_state is state then return Promise.resolve()
+      if @_state is state and not @forceExecution then return Promise.resolve()
       # and execute it.
       command = (if state then @config.onCommand else @config.offCommand)
       return exec(command).then( ({stdout, stderr}) =>

--- a/shell-execute.coffee
+++ b/shell-execute.coffee
@@ -101,7 +101,7 @@ module.exports = (env) ->
         )
         
     changeStateTo: (state) ->
-      if @state is state then return
+      if @_state is state then return
       # and execute it.
       command = (if state then @config.onCommand else @config.offCommand)
       return exec(command).then( ({stdout, stderr}) =>

--- a/shell-execute.coffee
+++ b/shell-execute.coffee
@@ -101,7 +101,7 @@ module.exports = (env) ->
         )
         
     changeStateTo: (state) ->
-      if @_state is state then return
+      if @_state is state then return Promise.resolve()
       # and execute it.
       command = (if state then @config.onCommand else @config.offCommand)
       return exec(command).then( ({stdout, stderr}) =>

--- a/shell-execute.coffee
+++ b/shell-execute.coffee
@@ -66,14 +66,19 @@ module.exports = (env) ->
 
       updateValue = =>
         if @config.interval > 0
+          @_updateValueTimeout = null
           @getState().finally( =>
-            setTimeout(updateValue, @config.interval) 
+            @_updateValueTimeout = setTimeout(updateValue, @config.interval)
           )
 
       super()
       if @config.getStateCommand?
         updateValue()
-        
+
+    destroy: () ->
+      clearTimeout @_updateValueTimeout if @_updateValueTimeout?
+      super()
+
     getState: () ->
       if not @config.getStateCommand?
         return Promise.resolve @_state
@@ -138,12 +143,17 @@ module.exports = (env) ->
 
       updateValue = =>
         if @config.interval > 0
+          @_updateValueTimeout = null
           @_getUpdatedAttributeValue().finally( =>
-            setTimeout(updateValue, @config.interval)
+            @_updateValueTimeout = setTimeout(updateValue, @config.interval)
           )
 
       super()
       updateValue()
+
+    destroy: () ->
+      clearTimeout @_updateValueTimeout if @_updateValueTimeout?
+      super()
 
     _getUpdatedAttributeValue: () ->
       return exec(@config.command).then( ({stdout, stderr}) =>
@@ -170,18 +180,27 @@ module.exports = (env) ->
 
       updateValue = =>
         if @config.interval > 0
+          @_updateValueTimeout = null
           @getPresence().finally( =>
-            setTimeout(updateValue, @config.interval)
+            @_updateValueTimeout = setTimeout(updateValue, @config.interval)
           )
 
       super()
       updateValue()
 
+    destroy: () ->
+      clearTimeout @_updateValueTimeout if @_updateValueTimeout?
+      clearTimeout @_resetPresenceTimeout if @_resetPresenceTimeout?
+      super()
+
     _triggerAutoReset: ->
       if @config.autoReset and @_presence
         clearTimeout(@_resetPresenceTimeout) if @_resetPresenceTimeout?
         @_resetPresenceTimeout = setTimeout(
-          ( => @_setPresence no )
+          ( () =>
+            @_setPresence no
+            @_resetPresenceTimeout = null
+          )
           , @config.resetTime
         )
 


### PR DESCRIPTION
Somehow the shell sensor device states that it does not find a number, but a string:

> error [pimatic]: Got string value for attribute Voltage of ShellSensor but attribute type is number.

This is easy to reproduce with the example:
`echo 42.0`
Also tried it with a python script and utf-8 decoding, but the same issue

Sorry that I opend a pull request, but I didn't figure out howto open an issue here.